### PR TITLE
seo: fix critical SEO issues and add structured data

### DIFF
--- a/BLOG_CONSTANTS/_BLOG_SETUP.tsx
+++ b/BLOG_CONSTANTS/_BLOG_SETUP.tsx
@@ -151,9 +151,9 @@ export const PRIMARY_NAV: iNavSetup = {
 }
 
 export const DEFAULT_SEO: iSEO = {
-    title: "Noel's Nonsense",
-    description: "Noel's Ramblings on Software Engineering, Leadership and Life.",
-    keywords: "leadership, management, team, software, development, python, typescript, react, fastapi",
+    title: "Noel Wilson | Software Engineering & Leadership Blog",
+    description: "Noel Wilson's blog on software engineering, cloud architecture, engineering leadership and team building — written from 15+ years of hands-on experience.",
+    keywords: "noel wilson, leadership, management, team, software engineering, cloud architecture, python, typescript, react, fastapi",
     url: WEBSITE_URL,
     author: `${NOEL.name}`,
     twitterHandle: '',

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: 'https://noel-wilson.co.uk',
+  generateRobotsTxt: true,
+  robotsTxtOptions: {
+    policies: [{ userAgent: '*', allow: '/' }],
+    additionalSitemaps: [],
+  },
+  trailingSlash: true,
+  // exclude template/tutorial pages that are not real content
+  exclude: ['/tutorial', '/tutorial/*'],
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start-prod": "next start",
     "lint": "next lint",
     "export": "next export",
-    "out": "next build && next export"
+    "out": "next build && next export && next-sitemap"
   },
   "dependencies": {
     "@rive-app/react-webgl2": "^4.22.1",
@@ -43,6 +43,7 @@
     "babel-loader": "^8.2.5",
     "eslint": "8.9.0",
     "eslint-config-next": "12.1.0",
+    "next-sitemap": "^4.2.3",
     "postcss": "^8.4.14",
     "tailwindcss": "^3.1.5",
     "typescript": "4.5.5",

--- a/pages/contact-me.tsx
+++ b/pages/contact-me.tsx
@@ -1,15 +1,14 @@
 /**These are necessary imports / components for the page */
-import { ImageSize, TextAlign, ListType } from "../src/shared/enums";
-import { PageLayout, Text, List, Image, LinkTo, Seperator, Slider  } from "../src/components";
+import { PageLayout, Text } from "../src/components";
 import { iSEO } from "../src/shared/interfaces";
 
 const ContactUs = () => {
     const PAGE_SEO: iSEO = {
         title: 'Contact Me',
-        description: 'For any any queries related to this project / template feel free to connect with us on webexpe13@gmail.com',
-        keywords: 'webexpx, contact me, webexpe13@gmail.com, next js blog template',
-        author: 'Mayur Nalwala, Rupali Yadav'
-    } 
+        description: 'Get in touch with Noel Wilson, Full Stack Engineer and Cloud Architect based in London.',
+        keywords: 'noel wilson, contact, full stack engineer, cloud architect, london',
+        author: 'Noel Wilson'
+    }
     return (
         <PageLayout PAGE_SEO={PAGE_SEO} home>
             <section className='container px-3 pb-10 md:pt-20 pt-[80px]'>
@@ -20,16 +19,15 @@ const ContactUs = () => {
                 <div className="flex flex-wrap mt-8 justify-between">
                     <div className="md:w-1/2 w-full md:pl-2">
                         <Text p className="!text-lg leading-relaxed">
-                            For any any queries related to this project / template feel free to connect with us at the given email.
-                            You can also post any comments on our <a href="https://github.com/webexpe13/blog-template-using-nextjs-typescript-tailwindcss/discussions" target="_blank" rel="noopener noreferrer"><u><i>github discussions</i></u></a>.
+                            Feel free to reach out if you want to chat about software engineering, leadership, cloud architecture, or just want to say hello.
                         </Text>
                     </div>
                     <div className="md:w-1/3 w-full">
                         <Text p>
-                            write to us at
+                            write to me at
                         </Text>
                         <Text subtitle className="!font-light md:!text-3xl">
-                            webexpe13@gmail.com
+                            jwnwilson@hotmail.co.uk
                         </Text>
                     </div>
                 </div>
@@ -38,10 +36,10 @@ const ContactUs = () => {
 
             <section className={"dark:bg-slate-800 bg-blue-100 mt-10 container py-10 md:px-20 px-5"}>
                 <Text subtitle className="md:!text-5xl text-4xl !font-light">
-                    Work with us . . .
+                    Work together . . .
                 </Text>
                 <Text p className="!text-lg leading-relaxed mt-5 px-1">
-                    We are a group of developers and designers with more than 5 years of industry experience. If you have any requirements like Website Development, Website / App Design feel free to contact me on the given email.
+                    I am an experienced full stack engineer, cloud architect and engineering manager with 15+ years of industry experience. If you have any requirements or just want to connect, feel free to reach out via email or on LinkedIn.
                 </Text>
             </section>
         </PageLayout>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://noel-wilson.co.uk/sitemap.xml

--- a/src/components/JsonLd/index.tsx
+++ b/src/components/JsonLd/index.tsx
@@ -1,0 +1,24 @@
+import Head from 'next/head'
+
+interface JsonLdProps {
+  schema: Record<string, unknown>
+  keyId: string
+}
+
+/**
+ * Injects a JSON-LD structured data script tag into <head>.
+ * Use keyId to prevent Next.js from deduplicating multiple schemas on the same page.
+ */
+const JsonLd = ({ schema, keyId }: JsonLdProps) => {
+  return (
+    <Head>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+        key={keyId}
+      />
+    </Head>
+  )
+}
+
+export default JsonLd

--- a/src/layouts/PageLayouts/index.tsx
+++ b/src/layouts/PageLayouts/index.tsx
@@ -1,12 +1,16 @@
+import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
-import { DEFAULT_SEO } from '../../../BLOG_CONSTANTS/_BLOG_SETUP';
+import { DEFAULT_SEO, WEBSITE_URL } from '../../../BLOG_CONSTANTS/_BLOG_SETUP';
+import JsonLd from '../../components/JsonLd';
 import Navbar from '../../components/Navbar';
 import { iSEO } from '../../shared/interfaces';
+import { buildBlogPostingSchema, buildPersonSchema } from '../../utils/schemas';
 import { CREATE_SEO_CONFIG, getArticleDetails } from '../../utils/utils';
 import Centered from './BlogCentered';
 import WithSidebar from './BlogWithSidebar';
 import HomeLayout from './HomeLayout';
 import StandardLayout from './StandardLayout';
+
 interface IBlogLayout {
     children: any
     PAGE_SEO?: iSEO,
@@ -18,7 +22,11 @@ interface IBlogLayout {
 }
 
 const PageLayout = ({ children, PAGE_SEO, blogwithsidebar = false, blogcentered = false, home = false, standard = false, ads = [] }: IBlogLayout) => {
-    const ARTICLE_DETAILS = getArticleDetails();    
+    const router = useRouter();
+    const ARTICLE_DETAILS = getArticleDetails();
+    const isHomePage = router.asPath === '/';
+    const pageUrl = `${WEBSITE_URL}${router.asPath}`;
+
     let SEO_CONFIG = {};
     if (ARTICLE_DETAILS && ARTICLE_DETAILS.seo) {
         SEO_CONFIG = CREATE_SEO_CONFIG({ ...ARTICLE_DETAILS.seo })
@@ -31,6 +39,15 @@ const PageLayout = ({ children, PAGE_SEO, blogwithsidebar = false, blogcentered 
     return (
         <>
             <NextSeo {...SEO_CONFIG} />
+            {isHomePage && (
+                <JsonLd schema={buildPersonSchema()} keyId="jsonld-person" />
+            )}
+            {ARTICLE_DETAILS && (
+                <JsonLd
+                    schema={buildBlogPostingSchema(ARTICLE_DETAILS, pageUrl)}
+                    keyId="jsonld-article"
+                />
+            )}
             <Navbar />
             {
                 blogwithsidebar ? <WithSidebar children={children} ads={ads} /> :

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -1,0 +1,60 @@
+import { iArticle } from '../shared/interfaces'
+import { WEBSITE_URL } from '../../BLOG_CONSTANTS/_BLOG_SETUP'
+import { transformImagePaths } from './utils'
+
+/**
+ * Builds a Schema.org Person schema for Noel Wilson.
+ * Used on the homepage to establish author identity in Google's knowledge graph.
+ */
+export const buildPersonSchema = (): Record<string, unknown> => ({
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Noel Wilson',
+  url: WEBSITE_URL,
+  jobTitle: 'Full Stack Engineer & Cloud Architect',
+  description:
+    'Experienced full stack engineer, cloud architect and engineering manager based in London with 15+ years of industry experience.',
+  sameAs: [
+    'https://www.linkedin.com/in/noel-wilson-0a194225/',
+    'https://www.instagram.com/noelwilsonlon/',
+  ],
+})
+
+/**
+ * Builds a Schema.org BlogPosting schema for a given article.
+ * Enables Google rich snippets (author, date, image) in search results.
+ */
+export const buildBlogPostingSchema = (
+  article: iArticle,
+  pageUrl: string
+): Record<string, unknown> => {
+  const datePublished = new Date(article.preview.date).toISOString()
+  const imageUrl = article.preview.thumbnail
+    ? `${WEBSITE_URL}${transformImagePaths(article.preview.thumbnail)}`
+    : undefined
+
+  const schema: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: article.preview.articleTitle,
+    description: article.preview.shortIntro,
+    author: {
+      '@type': 'Person',
+      name: article.preview.author.name,
+      url: WEBSITE_URL,
+    },
+    datePublished,
+    url: pageUrl,
+    publisher: {
+      '@type': 'Person',
+      name: 'Noel Wilson',
+      url: WEBSITE_URL,
+    },
+  }
+
+  if (imageUrl) {
+    schema.image = imageUrl
+  }
+
+  return schema
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -221,8 +221,8 @@ export const CREATE_SEO_CONFIG = (PAGE_SEO: iSEO) => {
       images: [
         {
           url: ogImage,
-          width: 1200,
-          height: 630,
+          width: 500,
+          height: 500,
           alt: title,
         },
       ],

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -202,7 +202,7 @@ export const CREATE_SEO_CONFIG = (PAGE_SEO: iSEO) => {
   let seo_config = {
     title: title,
     description: meta_description,
-    canonical: "https://noel-wilson.co.uk/",
+    canonical: ogUrl,
     additionalMetaTags: [
       {
         property: "keywords",
@@ -215,21 +215,20 @@ export const CREATE_SEO_CONFIG = (PAGE_SEO: iSEO) => {
     ],
     openGraph: {
       type: "website",
-      locale: "en_IN",
+      locale: "en_GB",
       url: ogUrl,
       site_name: WEBSITE_NAME,
       images: [
         {
           url: ogImage,
-          width: 500,
-          height: 500,
+          width: 1200,
+          height: 630,
           alt: title,
         },
       ],
     },
     twitter: {
       handle: twitterHandle,
-      site: ogUrl,
       cardType: "summary_large_image",
     },
   };


### PR DESCRIPTION
- Fix canonical URL: was hardcoded to homepage for every page; now uses dynamic ogUrl so article pages have correct canonicals
- Fix og:locale: en_IN -> en_GB (site is .co.uk / UK-based)
- Remove twitter:site URL (was incorrectly set to page URL, not @handle)
- Fix OG image dimensions: 500x500 -> 1200x630 (correct aspect ratio)
- Improve homepage title: add name and topic keywords for search signal
- Expand meta description with experience and topic context
- Fix contact page: remove template author SEO data (webexpe13@gmail.com, Mayur Nalwala) and replace with Noel's correct details
- Add next-sitemap package and config; wire into 'out' build script to generate sitemap.xml and robots.txt on each static export
- Update public/robots.txt with Sitemap directive
- Add JsonLd component for injecting JSON-LD structured data into <head>
- Add schema builders: buildPersonSchema (homepage) and buildBlogPostingSchema (article pages) for rich snippet eligibility
- Wire JsonLd into PageLayout for automatic schema injection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to SEO metadata, static export tooling, and marketing copy on the contact page with no auth, data, or runtime business-logic impact.
> 
> **Overview**
> This PR **tightens site-wide SEO** for Noel Wilson’s portfolio/blog and **automates crawl discovery** on static export.
> 
> **Meta & SEO config:** Default site title, description, and keywords are rewritten for branded search. `CREATE_SEO_CONFIG` now sets **canonical and Open Graph URLs per page** via `ogUrl` instead of a hardcoded homepage URL, switches **og:locale** to `en_GB`, and drops the incorrect **twitter:site** page URL.
> 
> **Contact page:** Template author/SEO copy (third-party emails and names) is replaced with Noel’s contact details and on-page messaging.
> 
> **Sitemaps & robots:** Adds `next-sitemap` with config for `noel-wilson.co.uk`, runs it in the **`out` build script**, and points `public/robots.txt` at the generated sitemap (tutorial routes excluded).
> 
> **Structured data:** New `JsonLd` component and `buildPersonSchema` / `buildBlogPostingSchema` helpers inject JSON-LD on the **homepage** and **article** layouts via `PageLayout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2260a5c7fdad7718fbbfafb639f719d9da9ea54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->